### PR TITLE
Fix exit code

### DIFF
--- a/filecheck/src/check/mod.rs
+++ b/filecheck/src/check/mod.rs
@@ -569,31 +569,52 @@ pub fn check_group<'section, 'input, 'a: 'input>(
                                                 }
                                                 | CheckFailedError::MatchFoundButDiscarded {
                                                     ..
-                                                } => {
-                                                    if span.start().to_usize() >= right_range.start
-                                                        || span.end().to_usize()
-                                                            >= right_range.start
-                                                    {
-                                                        *mr = MatchResult::failed(CheckFailedError::MatchFoundButDiscarded {
-                                                                span,
-                                                                input_file: context.input_file(),
-                                                                labels: vec![
-                                                                    RelatedLabel::error(
-                                                                        Label::new(pattern_span, "matched by this pattern"),
-                                                                        context.source_file(pattern_span.source_id()).unwrap()
+                                                } if (span.start().to_usize()
+                                                    >= right_range.start
+                                                    || span.end().to_usize()
+                                                        >= right_range.start) =>
+                                                {
+                                                    *mr = MatchResult::failed(
+                                                        CheckFailedError::MatchFoundButDiscarded {
+                                                            span,
+                                                            input_file: context.input_file(),
+                                                            labels: vec![
+                                                                RelatedLabel::error(
+                                                                    Label::new(
+                                                                        pattern_span,
+                                                                        "matched by this pattern",
                                                                     ),
-                                                                    RelatedLabel::warn(
-                                                                        Label::new(right_pattern_span, "because it cannot be reordered past this pattern"),
-                                                                        context.source_file(right_pattern_span.source_id()).unwrap()
+                                                                    context
+                                                                        .source_file(
+                                                                            pattern_span
+                                                                                .source_id(),
+                                                                        )
+                                                                        .unwrap(),
+                                                                ),
+                                                                RelatedLabel::warn(
+                                                                    Label::new(
+                                                                        right_pattern_span,
+                                                                        "because it cannot be reordered past this pattern",
                                                                     ),
-                                                                    RelatedLabel::note(
-                                                                        Label::point(context.input_file.id(), right_range.start as u32, "which begins here"),
-                                                                        context.input_file()
+                                                                    context
+                                                                        .source_file(
+                                                                            right_pattern_span
+                                                                                .source_id(),
+                                                                        )
+                                                                        .unwrap(),
+                                                                ),
+                                                                RelatedLabel::note(
+                                                                    Label::point(
+                                                                        context.input_file.id(),
+                                                                        right_range.start as u32,
+                                                                        "which begins here",
                                                                     ),
-                                                                ],
-                                                                note: None,
-                                                            });
-                                                    }
+                                                                    context.input_file(),
+                                                                ),
+                                                            ],
+                                                            note: None,
+                                                        },
+                                                    );
                                                 }
                                                 _ => (),
                                             }

--- a/filecheck/src/test/result.rs
+++ b/filecheck/src/test/result.rs
@@ -88,8 +88,7 @@ impl TestResult {
 
     pub fn into_result(mut self) -> Result<Vec<MatchInfo<'static>>, TestFailed> {
         if self.is_ok() {
-            self.matches
-                .sort_by(|a, b| a.pattern_span.start().cmp(&b.pattern_span.start()));
+            self.matches.sort_by_key(|a| a.pattern_span.start());
             Ok(self.matches)
         } else {
             Err(self.error)

--- a/litcheck/src/commands/lit.rs
+++ b/litcheck/src/commands/lit.rs
@@ -263,7 +263,14 @@ where
 
     print_results(&results_by_status, &config);
 
-    Ok(ExitCode::SUCCESS)
+    // Exit with a non-zero status code if any tests failed, or if the run
+    // was aborted before all tests could be executed.
+    let any_failed = results_by_status.keys().any(|status| status.is_failure());
+    if any_failed || result.is_err() {
+        Ok(ExitCode::FAILURE)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
 }
 
 enum SelectResult {

--- a/litcheck/tests/exit_code.rs
+++ b/litcheck/tests/exit_code.rs
@@ -1,0 +1,40 @@
+//! Integration tests verifying the process exit code of the `litcheck` binary.
+
+use std::process::Command;
+
+/// Build a [Command] that invokes the `litcheck` binary on the given lit test fixture.
+///
+/// The command runs from the workspace root, as lit requires test paths to be
+/// located under the current working directory.
+fn lit_run(fixture: &str) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_litcheck"));
+    cmd.current_dir(concat!(env!("CARGO_MANIFEST_DIR"), "/.."));
+    cmd.args(["lit", "run", &format!("tests/lit/{fixture}")]);
+    cmd
+}
+
+#[test]
+fn lit_run_exits_with_success_when_all_tests_pass() {
+    let output = lit_run("sanity").output().expect("failed to run litcheck");
+    assert!(
+        output.status.success(),
+        "expected exit code 0 for a passing test suite, got {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn lit_run_exits_with_failure_when_a_test_fails() {
+    let output = lit_run("exit-code-fail")
+        .output()
+        .expect("failed to run litcheck");
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "expected exit code 1 for a failing test suite\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/tests/lit/exit-code-fail/fail.txt
+++ b/tests/lit/exit-code-fail/fail.txt
@@ -1,0 +1,5 @@
+; This test always fails, it exists to verify that `lit run` exits with a
+; non-zero status code when a test fails.
+; RUN: echo hello | filecheck %s
+
+; CHECK: goodbye

--- a/tests/lit/exit-code-fail/lit.suite.toml
+++ b/tests/lit/exit-code-fail/lit.suite.toml
@@ -1,0 +1,4 @@
+name = "exit-code-fail"
+patterns = ["*.txt"]
+
+[format.shtest]


### PR DESCRIPTION
# fix(lit): exit with non-zero status code when tests fail

`lit run` always exited with code 0, even when tests failed — the collected
test results were printed but never consulted when determining the exit code,
contradicting the command's documented behavior. CI pipelines invoking
`litcheck lit` would therefore pass despite failing test suites — see
[this green `midenc lit/filecheck tests` job](https://github.com/0xMiden/compiler/actions/runs/27392138586/job/80951968370)
whose logs report `Failed Tests (2)`.

The runner now exits with code 1 when any test result has a failing status
(`Fail`, `XPass`, `Timeout`, `Unresolved`), or when the run is aborted before
all tests could execute. A new integration test invokes the `litcheck` binary
against passing and failing fixture suites and asserts on the process exit
code.

Also includes a one-off renormalization of `tests/filecheck/llvm/dos-style-eol.txt`
to an LF-stored blob, as required by its `eol=crlf` gitattribute — the blob had
been accidentally committed with literal CRLF, making the file permanently show
as modified.
